### PR TITLE
Don't spam skipped tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "jest-standard-reporter",
-  "version": "1.0.2",
+  "name": "@outlinerisk/jest-friendly-reporter",
+  "version": "0.1.0",
   "description": "Jest reporter that uses stdout for messages and stderr for errors",
   "main": "index.js",
   "scripts": {
@@ -10,10 +10,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chrisgalvan/jest-standard-reporter"
+    "url": "https://github.com/outline-insurance/jest-friendly-reporter"
   },
   "bugs": {
-    "url": "https://github.com/chrisgalvan/jest-standard-reporter/issues"
+    "url": "https://github.com/outline-insurance/jest-friendly-reporter"
   },
   "keywords": [
     "jest",

--- a/src/getTestResults.js
+++ b/src/getTestResults.js
@@ -31,7 +31,28 @@ const groupTestsBySuites = testResults => {
   return output;
 };
 
+const someTestsRan = (suite) => {
+  if (!suite.tests) {
+    return false
+  }
+  return suite.tests.find((test) => {
+    return test.status != 'pending'
+  })
+}
+
+const atLeastOneTestRan = (suite) => {
+  if (someTestsRan(suite)) {
+    return true
+  }
+  const one = !!suite.suites.find(atLeastOneTestRan)
+  return one
+}
+
 const getLogSuite = (suite, indentLevel) => {
+  if (!atLeastOneTestRan(suite)) {
+    return getLine(chalk.dim(`○ ${suite.title}`), indentLevel)
+  }
+
   let output = '';
 
   if (suite.title) {

--- a/src/getTestResults.js
+++ b/src/getTestResults.js
@@ -41,11 +41,11 @@ const someTestsRan = (suite) => {
 }
 
 const atLeastOneTestRan = (suite) => {
-  if (someTestsRan(suite)) {
-    return true
+  if (suite.__atLeastOneTestRan === undefined) {
+    suite.__atLeastOneTestRan = someTestsRan(suite)
+      || !!suite.suites.find(atLeastOneTestRan)
   }
-  const one = !!suite.suites.find(atLeastOneTestRan)
-  return one
+  return suite.__atLeastOneTestRan
 }
 
 const getLogSuite = (suite, indentLevel) => {


### PR DESCRIPTION
Just prints the toplevel describe block if we are skipping a whole tree of tests:

![focus](https://user-images.githubusercontent.com/53096171/66801483-0f5df400-eece-11e9-8b6a-482c009ed02d.gif)

With the standard reporter it's kind of hard to scroll through...

![zgPOGhEr2j](https://user-images.githubusercontent.com/53096171/66801789-2f41e780-eecf-11e9-877b-60f120440b32.gif)

